### PR TITLE
[PR1] DEV-108 add TCP sniffing

### DIFF
--- a/src/cmd/MVP-4/mappers.go
+++ b/src/cmd/MVP-4/mappers.go
@@ -48,11 +48,16 @@ func (table *IDtoType) AddPacket(board string, ip string, desc excelAdapterModel
 }
 
 func getFilter(raddrs []*net.TCPAddr) string {
-	filter := "udp && ("
+	hosts := "("
 	for _, addr := range raddrs {
-		filter += fmt.Sprintf("src host %s || ", addr.IP)
+		hosts += fmt.Sprintf("src host %s || ", addr.IP)
 	}
-	return strings.TrimSuffix(filter, " || ") + ")"
+	hosts = strings.TrimSuffix(hosts, " || ") + ") && ("
+	for _, addr := range raddrs {
+		hosts += fmt.Sprintf("dst host %s || ", addr.IP)
+	}
+	hosts = strings.TrimSuffix(hosts, " || ") + ")"
+	return "(udp && (" + hosts + ")) || (((tcp[tcpflags] & tcp-push) > 0) && (" + hosts + "))"
 }
 
 func getJSON(data any) []byte {

--- a/src/transport_controller/internals/sniffer.go
+++ b/src/transport_controller/internals/sniffer.go
@@ -7,13 +7,13 @@ import (
 	"github.com/google/gopacket/pcap"
 )
 
-const etherType = 12
-const ipType = etherType + 11
-const typeIPIP = 0x04
-const typeUDP = 0x11
-const typeTCP = 0x06
-const udpOffset = 42
-const tcpOffset = 54
+const ETHER_TYPE = 12
+const IP_TYPE = ETHER_TYPE + 11
+const TYPE_IPIP = 0x04
+const TYPE_UDP = 0x11
+const TYPE_TCP = 0x06
+const UDP_OFFSET = 42
+const TCP_OFFSET = 54
 
 type Sniffer struct {
 	source *pcap.Handle
@@ -64,22 +64,22 @@ func (sniffer *Sniffer) StartReading() {
 			continue
 		}
 
-		if payload[etherType] != 0x08 || payload[etherType+1] != 0x00 {
+		if payload[ETHER_TYPE] != 0x08 || payload[ETHER_TYPE+1] != 0x00 {
 			continue
 		}
 
-		switch payload[ipType] {
-		case typeIPIP:
-			switch payload[ipType+20] {
-			case typeUDP:
-				sniffer.config.Dump <- payload[udpOffset+20:]
-			case typeTCP:
-				sniffer.config.Dump <- payload[tcpOffset+20:]
+		switch payload[IP_TYPE] {
+		case TYPE_IPIP:
+			switch payload[IP_TYPE+20] {
+			case TYPE_UDP:
+				sniffer.config.Dump <- payload[UDP_OFFSET+20:]
+			case TYPE_TCP:
+				sniffer.config.Dump <- payload[TCP_OFFSET+20:]
 			}
-		case typeUDP:
-			sniffer.config.Dump <- payload[udpOffset:]
-		case typeTCP:
-			sniffer.config.Dump <- payload[tcpOffset:]
+		case TYPE_UDP:
+			sniffer.config.Dump <- payload[UDP_OFFSET:]
+		case TYPE_TCP:
+			sniffer.config.Dump <- payload[TCP_OFFSET:]
 		}
 
 	}


### PR DESCRIPTION
we can now capture TCP traffic generated by the boards not directed to the control station

The hexadecimal numbers in sniffer.go are the position of the values inside the packet, these identify if the payload is TCP/UDP and if it came from an IP in IP tunnel.