### PR TITLE
[PR-1] DEV-115: Using offline excel

### DIFF
--- a/src/excel_adapter/excel_adapter.go
+++ b/src/excel_adapter/excel_adapter.go
@@ -15,7 +15,10 @@ const GLOBAL_SHEET_NAME = "Info"
 const ADDRESSES_TABLE_NAME = "Addresses"
 
 func FetchDocument(id string, path string, name string) internalModels.Document {
-	internals.DownloadFile(id, path, name)
+	errDownloading := internals.DownloadFile(id, path, name)
+	if errDownloading != nil {
+		log.Println("USING LOCAL FILE")
+	}
 	file, err := excelize.OpenFile(filepath.Join(path, name))
 	if err != nil {
 		log.Fatalf("excel adapter: FetchDocument: %s\n", err)

--- a/src/excel_adapter/internals/excel_retriever.go
+++ b/src/excel_adapter/internals/excel_retriever.go
@@ -13,43 +13,61 @@ import (
 
 const sheetsMimeType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
-func DownloadFile(id string, path string, name string) {
-	saveFile(getFile(getClient(), id, sheetsMimeType), path, name)
+func DownloadFile(id string, path string, name string) error {
+	client, errClient := getClient()
+	if errClient != nil {
+		return errClient
+	}
+
+	file, errFile := getFile(client, id, sheetsMimeType)
+	if errFile != nil {
+		return errFile
+	}
+
+	errSaving := saveFile(file, path, name)
+
+	return errSaving
 }
 
-func getClient() *drive.Service {
+func getClient() (*drive.Service, error) {
 	ctx := context.Background()
 
 	client, err := drive.NewService(ctx, option.WithCredentialsFile(os.Getenv("CREDENTIALS")))
 	if err != nil {
-		log.Fatalf("excel retriever: getClient: %s\n", err)
+		log.Printf("excel retriever: the client could not be obtained")
+		return nil, err
 	}
 
-	return client
+	return client, nil
 }
 
-func getFile(client *drive.Service, id string, mimeType string) []byte {
+func getFile(client *drive.Service, id string, mimeType string) ([]byte, error) {
 	resp, err := client.Files.Export(id, mimeType).Download()
 	if err != nil {
-		log.Fatalf("excel retriever: getFile: %s\n", err)
+		log.Printf("excel retriever: getFile: could not download the file")
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
-		log.Fatalf("excel retriever: getFile: %s\n", err)
+		log.Printf("excel retriever: getFile: could not read the http response body")
+		return nil, err
 	}
 
-	return data
+	return data, nil
 }
 
-func saveFile(content []byte, path string, name string) {
+func saveFile(content []byte, path string, name string) error {
 	err := os.Mkdir(path, os.ModeDir)
 	if !os.IsExist(err) {
-		log.Fatalf("excel retriever: saveFile: %s\n", err)
+		log.Printf("excel retriever: saveFile: could not create the directory")
+		return err
 	}
 	err = os.WriteFile(filepath.Join(path, name), content, 0644) // rw-r--r--
 	if err != nil {
-		log.Fatalf("excel retriever: saveFile: %s\n", err)
+		log.Printf("excel retriever: saveFile: could not write the file in the directory")
+		return err
 	}
+	return nil
 }


### PR DESCRIPTION
When it is not possible to download the excel from the Drive, or any kind of error occurs that causes a failure, the last downloaded file is used. Reports by console the error that has occurred and that the local file is being used.