### PR TITLE
[PR1] DEV-141 add moving average

### DIFF
--- a/src/common/moving_average.go
+++ b/src/common/moving_average.go
@@ -1,0 +1,19 @@
+package common
+
+type MovingAverage[N Numeric] struct {
+	buf     RingBuf[N]
+	currAvg N
+}
+
+func NewMovingAverage[N Numeric](order uint) MovingAverage[N] {
+	return MovingAverage[N]{
+		buf:     NewRingBuf[N]((int)(order)),
+		currAvg: 0,
+	}
+}
+
+func (avg *MovingAverage[N]) Add(value N) N {
+	avg.currAvg += value / N(avg.buf.Len())
+	avg.currAvg -= avg.buf.Add(value) / N(avg.buf.Len())
+	return avg.currAvg
+}

--- a/src/common/moving_average.go
+++ b/src/common/moving_average.go
@@ -22,6 +22,16 @@ func (avg *MovingAverage[N]) Order() int {
 	return avg.buf.Len()
 }
 
+func (avg *MovingAverage[N]) Resize(order uint) N {
+	if order > (uint)(avg.Order()) {
+		avg.Grow(order - (uint)(avg.Order()))
+	} else if order < (uint)(avg.Order()) {
+		avg.Shrink((uint)(avg.Order()) - order)
+	}
+
+	return avg.currAvg
+}
+
 func (avg *MovingAverage[N]) Shrink(amount uint) N {
 	avg.currAvg *= N(avg.Order())
 	for _, removed := range avg.buf.Shrink(amount) {

--- a/src/common/moving_average.go
+++ b/src/common/moving_average.go
@@ -17,3 +17,27 @@ func (avg *MovingAverage[N]) Add(value N) N {
 	avg.currAvg -= avg.buf.Add(value) / N(avg.buf.Len())
 	return avg.currAvg
 }
+
+func (avg *MovingAverage[N]) Order() int {
+	return avg.buf.Len()
+}
+
+func (avg *MovingAverage[N]) Shrink(amount uint) N {
+	avg.currAvg *= N(avg.Order())
+	for _, removed := range avg.buf.Shrink(amount) {
+		avg.currAvg -= removed
+	}
+	avg.currAvg /= N(avg.Order())
+
+	return avg.currAvg
+}
+
+func (avg *MovingAverage[N]) Grow(amount uint) N {
+	avg.currAvg *= N(avg.Order())
+	for _, added := range avg.buf.Grow(amount) {
+		avg.currAvg += added
+	}
+	avg.currAvg /= N(avg.Order())
+
+	return avg.currAvg
+}

--- a/src/common/ring_buf.go
+++ b/src/common/ring_buf.go
@@ -19,16 +19,6 @@ func (buf *RingBuf[T]) Add(value T) (evicted T) {
 	return evicted
 }
 
-func (buf *RingBuf[T]) push(new T) {
-	head := append(buf.buf[:buf.next()], new)
-	buf.buf = append(head, buf.buf[buf.next():]...)
-}
-
-func (buf *RingBuf[T]) pop() (removed T) {
-	buf.buf, removed = Remove(buf.buf, buf.curr)
-	return removed
-}
-
 func (buf *RingBuf[T]) next() int {
 	return (buf.curr + 1) % buf.Len()
 }
@@ -50,6 +40,11 @@ func (buf *RingBuf[T]) Shrink(amount uint) []T {
 	return removed
 }
 
+func (buf *RingBuf[T]) pop() (removed T) {
+	buf.buf, removed = Remove(buf.buf, buf.curr)
+	return removed
+}
+
 func (buf *RingBuf[T]) Grow(amount uint) []T {
 	added := make([]T, 0, amount)
 
@@ -60,4 +55,9 @@ func (buf *RingBuf[T]) Grow(amount uint) []T {
 	}
 
 	return added
+}
+
+func (buf *RingBuf[T]) push(new T) {
+	head := append(buf.buf[:buf.next()], new)
+	buf.buf = append(head, buf.buf[buf.next():]...)
 }

--- a/src/common/ring_buf.go
+++ b/src/common/ring_buf.go
@@ -27,6 +27,16 @@ func (buf *RingBuf[T]) Len() int {
 	return len(buf.buf)
 }
 
+func (buf *RingBuf[T]) Resize(size uint) []T {
+	if size > (uint)(buf.Len()) {
+		return buf.Grow(size - (uint)(buf.Len()))
+	} else if size < (uint)(buf.Len()) {
+		return buf.Shrink((uint)(buf.Len()) - size)
+	}
+
+	return nil
+}
+
 func (buf *RingBuf[T]) Shrink(amount uint) []T {
 	removed := make([]T, 0, amount)
 

--- a/src/common/ring_buf.go
+++ b/src/common/ring_buf.go
@@ -1,0 +1,63 @@
+package common
+
+type RingBuf[T any] struct {
+	buf  []T
+	curr int
+}
+
+func NewRingBuf[T any](size int) RingBuf[T] {
+	return RingBuf[T]{
+		buf:  make([]T, size),
+		curr: 0,
+	}
+}
+
+func (buf *RingBuf[T]) Add(value T) (evicted T) {
+	evicted = buf.buf[buf.curr]
+	buf.buf[buf.curr] = value
+	buf.curr = buf.next()
+	return evicted
+}
+
+func (buf *RingBuf[T]) push(new T) {
+	head := append(buf.buf[:buf.next()], new)
+	buf.buf = append(head, buf.buf[buf.next():]...)
+}
+
+func (buf *RingBuf[T]) pop() (removed T) {
+	buf.buf, removed = Remove(buf.buf, buf.curr)
+	return removed
+}
+
+func (buf *RingBuf[T]) next() int {
+	return (buf.curr + 1) % buf.Len()
+}
+
+func (buf *RingBuf[T]) Len() int {
+	return len(buf.buf)
+}
+
+func (buf *RingBuf[T]) Shrink(amount uint) []T {
+	removed := make([]T, 0, amount)
+
+	for i := (uint)(0); i < amount; i++ {
+		removed = append(removed, buf.pop())
+		if buf.curr >= buf.Len() {
+			buf.curr--
+		}
+	}
+
+	return removed
+}
+
+func (buf *RingBuf[T]) Grow(amount uint) []T {
+	added := make([]T, 0, amount)
+
+	for i := (uint)(0); i < amount; i++ {
+		var new T
+		added = append(added, new)
+		buf.push(new)
+	}
+
+	return added
+}

--- a/src/common/slice.go
+++ b/src/common/slice.go
@@ -1,0 +1,7 @@
+package common
+
+func Remove[T any](slice []T, i int) (after []T, removed T) {
+	removed = slice[i]
+	after = append(slice[:i], slice[i+1:]...)
+	return after, removed
+}

--- a/src/common/types.go
+++ b/src/common/types.go
@@ -1,0 +1,17 @@
+package common
+
+type Numeric interface{ Integer | Float }
+
+type Integer interface {
+	SignedInteger | UnsignedInteger
+}
+
+type SignedInteger interface {
+	int | int8 | int16 | int32 | int64
+}
+
+type UnsignedInteger interface {
+	uint | uint8 | uint16 | uint32 | uint64
+}
+
+type Float interface{ float32 | float64 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -6,7 +6,7 @@ file_server_path = "static" # Change name to front build path
 
 [server.endpoints]
 pod_data = "/podDataStructure"
-order_data = "/orderDataStructure"
+order_data = "/orderStructures"
 websocket = "/backend"
 file_server = "/"
 

--- a/src/main.go
+++ b/src/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	_ "net/http/pprof"
 	"os"
 	"os/signal"
@@ -87,8 +86,7 @@ func main() {
 				err := messageTransfer.SendMessage(m)
 
 				if err != nil {
-					//TODO: change to trace?
-					fmt.Println("Error sending message")
+					trace.Error().Err(err).Stack().Msg("error sending message")
 				}
 			case message_parser_models.BLCU_ACK:
 				blcu.HandleACK()

--- a/src/message_parser/models/blcu_ack.go
+++ b/src/message_parser/models/blcu_ack.go
@@ -1,4 +1,3 @@
 package models
 
-type BLCU_ACK struct {
-}
+type BLCU_ACK struct{}

--- a/src/message_parser/models/protection_message.go
+++ b/src/message_parser/models/protection_message.go
@@ -19,35 +19,40 @@ type ProtectionMessage struct {
 
 type ProtectionTimestamp struct {
 	Counter uint16 `json:"counter"`
-	Second  uint8  `json:"second"`
-	Minute  uint8  `json:"minute"`
-	Hour    uint8  `json:"hour"`
+	Seconds uint8  `json:"seconds"`
+	Minutes uint8  `json:"minutes"`
+	Hours   uint8  `json:"hours"`
 	Day     uint8  `json:"day"`
 	Month   uint8  `json:"month"`
 	Year    uint8  `json:"year"`
 }
 
 type OutOfBoundsViolation struct {
+	Kind string     `json:"kind"`
 	Want [2]float64 `json:"want"`
 	Got  float64    `json:"got"`
 }
 
 type UpperBoundViolation struct {
+	Kind string  `json:"kind"`
 	Want float64 `json:"want"`
 	Got  float64 `json:"got"`
 }
 
 type LowerBoundViolation struct {
+	Kind string  `json:"kind"`
 	Want float64 `json:"want"`
 	Got  float64 `json:"got"`
 }
 
 type EqualsViolation struct {
+	Kind string  `json:"kind"`
 	Want float64 `json:"want"`
 	Got  float64 `json:"got"`
 }
 
 type NotEqualsViolation struct {
+	Kind string  `json:"kind"`
 	Want float64 `json:"want"`
 	Got  float64 `json:"got"`
 }
@@ -122,6 +127,7 @@ func getOutOfBoundsViolation(violationParts []string) (OutOfBoundsViolation, err
 	}
 
 	return OutOfBoundsViolation{
+		Kind: "OUT_OF_BOUNDS",
 		Want: [2]float64{lowerBound, upperBound},
 		Got:  got,
 	}, nil
@@ -143,6 +149,7 @@ func getUpperBoundViolation(violationParts []string) (UpperBoundViolation, error
 	}
 
 	return UpperBoundViolation{
+		Kind: "UPPER_BOUND",
 		Want: upperBound,
 		Got:  got,
 	}, nil
@@ -164,6 +171,7 @@ func getLowerBoundViolation(violationParts []string) (LowerBoundViolation, error
 	}
 
 	return LowerBoundViolation{
+		Kind: "LOWER_BOUND",
 		Want: lowerBound,
 		Got:  got,
 	}, nil
@@ -185,6 +193,7 @@ func getEqualsViolation(violationParts []string) (EqualsViolation, error) {
 	}
 
 	return EqualsViolation{
+		Kind: "EQUALS",
 		Want: want,
 		Got:  got,
 	}, nil
@@ -206,6 +215,7 @@ func getNotEqualsViolation(violationParts []string) (NotEqualsViolation, error) 
 	}
 
 	return NotEqualsViolation{
+		Kind: "NOT_EQUALS",
 		Want: want,
 		Got:  got,
 	}, nil

--- a/src/message_parser/models/protection_message.go
+++ b/src/message_parser/models/protection_message.go
@@ -1,15 +1,30 @@
 package models
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"strconv"
+
+	trace "github.com/rs/zerolog/log"
 )
 
 type ProtectionMessage struct {
-	Kind      string `json:"kind"`
-	Board     string `json:"board"`
-	Value     string `json:"value"`
-	Violation any    `json:"violation"`
+	Kind      string              `json:"kind"`
+	Board     string              `json:"board"`
+	Value     string              `json:"value"`
+	Violation any                 `json:"violation"`
+	Timestamp ProtectionTimestamp `json:"timestamp"`
+}
+
+type ProtectionTimestamp struct {
+	Counter uint16 `json:"counter"`
+	Second  uint8  `json:"second"`
+	Minute  uint8  `json:"minute"`
+	Hour    uint8  `json:"hour"`
+	Day     uint8  `json:"day"`
+	Month   uint8  `json:"month"`
+	Year    uint8  `json:"year"`
 }
 
 type OutOfBoundsViolation struct {
@@ -37,11 +52,19 @@ type NotEqualsViolation struct {
 	Got  float64 `json:"got"`
 }
 
-func ParseProtectionMessage(kind string, messageParts []string) ProtectionMessage {
+func ParseProtectionMessage(kind string, messageParts []string) (ProtectionMessage, error) {
 	violation, err := getViolation(messageParts[2:])
 
 	if err != nil {
-		//TODO: error
+		trace.Error().Err(err).Stack().Msg("parse violation")
+		return ProtectionMessage{}, err
+	}
+
+	timestamp, err := getTimestamp(messageParts[len(messageParts)-1])
+
+	if err != nil {
+		trace.Error().Err(err).Stack().Msg("parse timestamp")
+		return ProtectionMessage{}, err
 	}
 
 	return ProtectionMessage{
@@ -49,128 +72,141 @@ func ParseProtectionMessage(kind string, messageParts []string) ProtectionMessag
 		Board:     messageParts[0],
 		Value:     messageParts[1],
 		Violation: violation,
-	}
+		Timestamp: timestamp,
+	}, nil
+}
+
+func getTimestamp(timestamp string) (ProtectionTimestamp, error) {
+	var protectionTimestamp ProtectionTimestamp
+	err := binary.Read(bytes.NewBuffer([]byte(timestamp)), binary.LittleEndian, &protectionTimestamp)
+	return protectionTimestamp, err
 }
 
 func getViolation(violationParts []string) (any, error) {
 	switch kind := violationParts[0]; kind {
 	case "OUT_OF_BOUNDS":
-		return getOutOfBoundsViolation(violationParts), nil
+		return getOutOfBoundsViolation(violationParts)
 	case "UPPER_BOUND":
-		return getUpperBoundViolation(violationParts), nil
+		return getUpperBoundViolation(violationParts)
 	case "LOWER_BOUND":
-		return getLowerBoundViolation(violationParts), nil
+		return getLowerBoundViolation(violationParts)
 	case "EQUALS":
-		return getEqualsViolation(violationParts), nil
+		return getEqualsViolation(violationParts)
 	case "NOT_EQUALS":
-		return getNotEqualsViolation(violationParts), nil
-	default: //TODO: undo kind of message
+		return getNotEqualsViolation(violationParts)
+	default:
 		return nil, errors.New("incorrect violation kind")
 	}
 }
 
-func getOutOfBoundsViolation(violationParts []string) OutOfBoundsViolation {
+func getOutOfBoundsViolation(violationParts []string) (OutOfBoundsViolation, error) {
 	got, gotErr := strconv.ParseFloat(violationParts[1], 64)
 
 	if gotErr != nil {
-		//TODO: error
-
+		trace.Error().Err(gotErr).Stack().Msg("parse got")
+		return OutOfBoundsViolation{}, gotErr
 	}
 
 	lowerBound, lowerErr := strconv.ParseFloat(violationParts[2], 64)
 
 	if lowerErr != nil {
-		//TODO: error
+		trace.Error().Err(lowerErr).Stack().Msg("parse lower")
+		return OutOfBoundsViolation{}, lowerErr
 	}
 
 	upperBound, upperErr := strconv.ParseFloat(violationParts[3], 64)
 
 	if upperErr != nil {
-		//TODO: error
+		trace.Error().Err(upperErr).Stack().Msg("parse upper")
+		return OutOfBoundsViolation{}, upperErr
 	}
 
 	return OutOfBoundsViolation{
 		Want: [2]float64{lowerBound, upperBound},
 		Got:  got,
-	}
+	}, nil
 }
 
-func getUpperBoundViolation(violationParts []string) UpperBoundViolation {
+func getUpperBoundViolation(violationParts []string) (UpperBoundViolation, error) {
 	got, gotErr := strconv.ParseFloat(violationParts[1], 64)
 
 	if gotErr != nil {
-		//TODO: error
-
+		trace.Error().Err(gotErr).Stack().Msg("parse got")
+		return UpperBoundViolation{}, gotErr
 	}
 
 	upperBound, upperErr := strconv.ParseFloat(violationParts[2], 64)
 
 	if upperErr != nil {
-		//TODO: error
-
+		trace.Error().Err(upperErr).Stack().Msg("parse upper")
+		return UpperBoundViolation{}, upperErr
 	}
 
 	return UpperBoundViolation{
 		Want: upperBound,
 		Got:  got,
-	}
+	}, nil
 }
 
-func getLowerBoundViolation(violationParts []string) LowerBoundViolation {
+func getLowerBoundViolation(violationParts []string) (LowerBoundViolation, error) {
 	got, gotErr := strconv.ParseFloat(violationParts[1], 64)
 
 	if gotErr != nil {
-		//TODO: error
-
+		trace.Error().Err(gotErr).Stack().Msg("parse got")
+		return LowerBoundViolation{}, gotErr
 	}
 
 	lowerBound, lowerErr := strconv.ParseFloat(violationParts[2], 64)
 
 	if lowerErr != nil {
-		//TODO: error
+		trace.Error().Err(lowerErr).Stack().Msg("parse lower")
+		return LowerBoundViolation{}, lowerErr
 	}
 
 	return LowerBoundViolation{
 		Want: lowerBound,
 		Got:  got,
-	}
+	}, nil
 }
 
-func getEqualsViolation(violationParts []string) EqualsViolation {
+func getEqualsViolation(violationParts []string) (EqualsViolation, error) {
 	got, gotErr := strconv.ParseFloat(violationParts[1], 64)
 
 	if gotErr != nil {
-		//TODO: error
-
+		trace.Error().Err(gotErr).Stack().Msg("parse got")
+		return EqualsViolation{}, gotErr
 	}
 
 	want, wantErr := strconv.ParseFloat(violationParts[2], 64)
 
 	if wantErr != nil {
-		//TODO: error
+		trace.Error().Err(wantErr).Stack().Msg("parse want")
+		return EqualsViolation{}, wantErr
 	}
 
 	return EqualsViolation{
 		Want: want,
 		Got:  got,
-	}
+	}, nil
 }
 
-func getNotEqualsViolation(violationParts []string) NotEqualsViolation {
+func getNotEqualsViolation(violationParts []string) (NotEqualsViolation, error) {
 	got, gotErr := strconv.ParseFloat(violationParts[1], 64)
 
 	if gotErr != nil {
-		//TODO: error
+		trace.Error().Err(gotErr).Stack().Msg("parse got")
+		return NotEqualsViolation{}, gotErr
 	}
 
 	want, wantErr := strconv.ParseFloat(violationParts[2], 64)
 
 	if wantErr != nil {
-		//TODO: error
+		trace.Error().Err(wantErr).Stack().Msg("parse want")
+		return NotEqualsViolation{}, wantErr
 	}
 
 	return NotEqualsViolation{
 		Want: want,
 		Got:  got,
-	}
+	}, nil
 }

--- a/src/unit_converter/unit_converter.go
+++ b/src/unit_converter/unit_converter.go
@@ -74,7 +74,7 @@ func (converter *UnitConverter) Revert(values map[string]any) map[string]any {
 	convertedValues := make(map[string]any, len(values))
 	for name, value := range values {
 		if ops, ok := converter.operations[name]; ok {
-			convertedValues[name] = ops.Convert(value.(float64))
+			convertedValues[name] = ops.Revert(value.(float64))
 		} else {
 			convertedValues[name] = value
 		}

--- a/src/vehicle/internals/update_factory.go
+++ b/src/vehicle/internals/update_factory.go
@@ -4,43 +4,97 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/HyperloopUPV-H8/Backend-H8/common"
 	"github.com/HyperloopUPV-H8/Backend-H8/vehicle/models"
 	"github.com/rs/zerolog"
 	trace "github.com/rs/zerolog/log"
 )
 
+const DEFAULT_ORDER = 20
+
 type UpdateFactory struct {
-	count     map[uint16]uint64
-	timestamp map[uint16]uint64
-	trace     zerolog.Logger
+	count        map[uint16]uint64
+	cycleTimeAvg map[uint16]*common.MovingAverage[uint64]
+	timestamp    map[uint16]uint64
+	fieldAvg     map[uint16]map[string]*common.MovingAverage[float64]
+	trace        zerolog.Logger
 }
 
 func NewFactory() UpdateFactory {
 	trace.Info().Msg("new update factory")
 	return UpdateFactory{
-		count:     make(map[uint16]uint64),
-		timestamp: make(map[uint16]uint64),
-		trace:     trace.With().Str("component", "updateFactory").Logger(),
+		count:        make(map[uint16]uint64),
+		cycleTimeAvg: make(map[uint16]*common.MovingAverage[uint64]),
+		timestamp:    make(map[uint16]uint64),
+		fieldAvg:     make(map[uint16]map[string]*common.MovingAverage[float64]),
+		trace:        trace.With().Str("component", "updateFactory").Logger(),
 	}
 }
 
 func (factory UpdateFactory) NewUpdate(id uint16, hexValue []byte, fields map[string]any) models.Update {
-	count, cycleTime := factory.getNext(id)
+	count, cycleTime, averages := factory.getNext(id, fields)
 	factory.trace.Trace().Uint16("id", id).Uint64("count", count).Uint64("cycleTime", cycleTime).Msg("new update")
+
 	return models.Update{
 		ID:        id,
 		HexValue:  fmt.Sprintf("%x", hexValue),
 		Fields:    fields,
+		Averages:  averages,
 		Count:     count,
 		CycleTime: cycleTime,
 	}
 }
 
-func (factory UpdateFactory) getNext(id uint16) (count uint64, cycleTime uint64) {
+func (factory UpdateFactory) getNext(id uint16, fields map[string]any) (count uint64, cycleTime uint64, averages map[string]any) {
 	timestamp := uint64(time.Now().UnixMicro())
-	cycleTime = timestamp - factory.timestamp[id]
+
+	cycleTime = factory.getCycleTime(id, timestamp)
+
 	factory.timestamp[id] = timestamp
+
 	factory.count[id] += 1
 	count = factory.count[id]
-	return
+
+	averages = factory.getAverages(id, fields)
+
+	return count, cycleTime, averages
+}
+
+func (factory UpdateFactory) getCycleTime(id uint16, timestamp uint64) uint64 {
+	if _, ok := factory.cycleTimeAvg[id]; !ok {
+		movAvg := common.NewMovingAverage[uint64](DEFAULT_ORDER)
+		factory.cycleTimeAvg[id] = &movAvg
+	}
+
+	return factory.cycleTimeAvg[id].Add(factory.timestamp[id] - timestamp)
+}
+
+func (factory UpdateFactory) getAverages(id uint16, fields map[string]any) map[string]any {
+	averages := make(map[string]any, len(fields))
+	for key, value := range fields {
+		averages[key] = factory.getAverage(id, key, value)
+	}
+	return averages
+}
+
+func (factory UpdateFactory) getAverage(id uint16, key string, value any) any {
+	switch value := value.(type) {
+	case float64:
+		return factory.getFloatAverage(id, key, value)
+	default:
+		return value
+	}
+}
+
+func (factory UpdateFactory) getFloatAverage(id uint16, key string, value float64) float64 {
+	if _, ok := factory.fieldAvg[id]; !ok {
+		factory.fieldAvg[id] = make(map[string]*common.MovingAverage[float64])
+	}
+
+	if _, ok := factory.fieldAvg[id][key]; !ok {
+		movAvg := common.NewMovingAverage[float64](DEFAULT_ORDER)
+		factory.fieldAvg[id][key] = &movAvg
+	}
+
+	return factory.fieldAvg[id][key].Add(value)
 }

--- a/src/vehicle/internals/update_factory.go
+++ b/src/vehicle/internals/update_factory.go
@@ -10,7 +10,7 @@ import (
 	trace "github.com/rs/zerolog/log"
 )
 
-const DEFAULT_ORDER = 20
+const DEFAULT_ORDER = 100
 
 type UpdateFactory struct {
 	count        map[uint16]uint64
@@ -66,7 +66,11 @@ func (factory UpdateFactory) getCycleTime(id uint16, timestamp uint64) uint64 {
 		factory.cycleTimeAvg[id] = &movAvg
 	}
 
-	return factory.cycleTimeAvg[id].Add(factory.timestamp[id] - timestamp)
+	if _, ok := factory.timestamp[id]; !ok {
+		factory.timestamp[id] = timestamp
+	}
+
+	return factory.cycleTimeAvg[id].Add(timestamp - factory.timestamp[id])
 }
 
 func (factory UpdateFactory) getAverages(id uint16, fields map[string]any) map[string]any {
@@ -96,5 +100,5 @@ func (factory UpdateFactory) getFloatAverage(id uint16, key string, value float6
 		factory.fieldAvg[id][key] = &movAvg
 	}
 
-	return factory.fieldAvg[id][key].Add(value)
+	return (float64)((int)(factory.fieldAvg[id][key].Add(value)*1000)) / 1000
 }

--- a/src/vehicle/models/update.go
+++ b/src/vehicle/models/update.go
@@ -6,4 +6,5 @@ type Update struct {
 	Count     uint64         `json:"count"`
 	CycleTime uint64         `json:"cycleTime"`
 	Fields    map[string]any `json:"measurementUpdates"`
+	Averages  map[string]any `json:"measurementAverages"`
 }

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -45,7 +45,7 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.Update, messagesChan cha
 
 			id, fields := vehicle.parser.Decode(rawCopy)
 			fields = vehicle.podConverter.Convert(fields)
-			fields = vehicle.displayConverter.Convert(fields)
+			fields = vehicle.displayConverter.Revert(fields)
 
 			update := vehicle.packetFactory.NewUpdate(id, rawCopy, fields)
 
@@ -78,7 +78,7 @@ func (vehicle *Vehicle) SendOrder(order models.Order) error {
 	}
 
 	fields := order.Fields
-	fields = vehicle.displayConverter.Revert(fields)
+	fields = vehicle.displayConverter.Convert(fields)
 	fields = vehicle.podConverter.Revert(fields)
 	raw := vehicle.parser.Encode(order.ID, fields)
 

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -57,7 +57,12 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.Update, messagesChan cha
 	}()
 	go func() {
 		for raw := range vehicle.messageChan {
-			messagesChan <- vehicle.messageParser.Parse(raw)
+			msg, err := vehicle.messageParser.Parse(raw)
+			if err != nil {
+				vehicle.trace.Error().Stack().Err(err).Str("raw", fmt.Sprintf("%#v", string(raw))).Msg("parse message")
+				continue
+			}
+			messagesChan <- msg
 		}
 	}()
 


### PR DESCRIPTION
_DO NOT MERGE BEFORE DEV-140, this branch originates from DEV-140 as the changes there were necessary to test with the front end_

Previously values were sent raw and were difficult to visualize in Ethernet View, this implements a moving average for numeric values and the cycle time so it is easier to see when just a number is displayed.

The moving average takes the N (currently set to 100) last values and computes the mean. Ideally, in the future N will be calculated based on the cycle time itself, so the average for less frequent packets is closer to the real value.

There are also some fixes to the unit conversion logic that wasn't working as expected.