### PR TITLE
[PR 1] DEV-170 limit the max number of websocket connections

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/HyperloopUPV-H8/Backend-H8/server"
 	"github.com/HyperloopUPV-H8/Backend-H8/value_logger"
 	"github.com/HyperloopUPV-H8/Backend-H8/vehicle"
+	"github.com/HyperloopUPV-H8/Backend-H8/websocket_broker"
 )
 
 type Config struct {
@@ -26,7 +27,8 @@ type Config struct {
 	Orders           struct {
 		SendTopic string `toml:"send_topic"`
 	}
-	Messages message_transfer.MessageTransferConfig
-	Server   server.ServerConfig
-	BLCU     blcu.BLCUConfig `toml:"blcu"`
+	Messages  message_transfer.MessageTransferConfig
+	Server    server.ServerConfig
+	BLCU      blcu.BLCUConfig `toml:"blcu"`
+	Websocket websocket_broker.Config
 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -46,11 +46,11 @@ message_ids_table = "message_ids"
 [logger_handler]
 topics = { enable = "logger/enable" }
 base_path = "log"
-flush_interval="5s"
+flush_interval = "5s"
 
 [packet_logger]
 file_name = "packets"
-flush_interval="5s"
+flush_interval = "5s"
 
 [value_logger]
 folder_name = "values"
@@ -58,11 +58,11 @@ flush_interval = "5s"
 
 [order_logger]
 file_name = "orders"
-flush_interval="5s"
+flush_interval = "5s"
 
 [protection_logger]
 file_name = "protections"
-flush_interval="5s"
+flush_interval = "5s"
 
 [orders]
 send_topic = "order/send"
@@ -85,3 +85,6 @@ ack = { name = "tftp_ack" }
 [blcu.topics]
 upload = "blcu/upload"
 download = "blcu/download"
+
+[websocket]
+max_connections = 190

--- a/src/main.go
+++ b/src/main.go
@@ -100,7 +100,7 @@ func main() {
 
 	loggerHandler := logger_handler.NewLoggerHandler(loggers, config.LoggerHandler)
 
-	websocketBroker := websocket_broker.New()
+	websocketBroker := websocket_broker.New(config.Websocket)
 	defer websocketBroker.Close()
 
 	websocketBroker.RegisterHandle(&blcu, config.BLCU.Topics.Upload, config.BLCU.Topics.Download)

--- a/src/websocket_broker/config.go
+++ b/src/websocket_broker/config.go
@@ -1,0 +1,5 @@
+package websocket_broker
+
+type Config struct {
+	MaxConnextions uint `toml:"max_connextions"`
+}

--- a/src/websocket_broker/config.go
+++ b/src/websocket_broker/config.go
@@ -1,5 +1,5 @@
 package websocket_broker
 
 type Config struct {
-	MaxConnextions uint `toml:"max_connextions"`
+	MaxConnections uint `toml:"max_connections"`
 }

--- a/src/websocket_broker/ws_handle.go
+++ b/src/websocket_broker/ws_handle.go
@@ -43,7 +43,7 @@ func (broker *WebSocketBroker) HandleConn(writter http.ResponseWriter, request *
 
 	writter.Header().Set("Access-Control-Allow-Origin", "*")
 
-	if broker.currentConns() >= broker.config.MaxConnextions {
+	if broker.currentConns() >= broker.config.MaxConnections {
 		broker.trace.Warn().Msg("max connextions reached")
 		http.Error(writter, "max connextions reached", http.StatusTooManyRequests)
 		return


### PR DESCRIPTION
This PR updates a little bit the websocket broker logic to limit the max users that can connect at the same time, it uses the length of the connection map, that gets updated each time a client connects/disconnects.