### PR TITLE
[PR 1] DEV-171 add support for multiple HTTP servers and rate limit

### DIFF
--- a/src/config.go
+++ b/src/config.go
@@ -29,6 +29,4 @@ type Config struct {
 	Messages message_transfer.MessageTransferConfig
 	Server   server.Config
 	BLCU     blcu.BLCUConfig `toml:"blcu"`
-
-	Test map[string]uint `toml:"test"`
 }

--- a/src/config.go
+++ b/src/config.go
@@ -27,6 +27,8 @@ type Config struct {
 		SendTopic string `toml:"send_topic"`
 	}
 	Messages message_transfer.MessageTransferConfig
-	Server   server.ServerConfig
+	Server   server.Config
 	BLCU     blcu.BLCUConfig `toml:"blcu"`
+
+	Test map[string]uint `toml:"test"`
 }

--- a/src/config.toml
+++ b/src/config.toml
@@ -1,14 +1,38 @@
 
-[server]
-#address = "192.168.0.9:4000"
-address = "127.0.0.1:4000"
-file_server_path = "static" # Change name to front build path
+[server.local]
+address = "localhost:4000"
+client_limit = 1
+static = "./static/local"
 
-[server.endpoints]
+[server.local.endpoints]
 pod_data = "/podDataStructure"
 order_data = "/orderStructures"
-uploadable_boards = "/uploadableBoards"
-websocket = "/backend"
+programable_boards = "/uploadableBoards"
+connections = "/backend"
+file_server = "/"
+
+[server.audience]
+address = "172.16.0.2:4000"
+client_limit = 2
+static = "./static/audience"
+
+[server.audience.endpoints]
+pod_data = "/podDataStructure"
+order_data = "/orderStructures"
+programable_boards = "/uploadableBoards"
+connections = "/backend"
+file_server = "/"
+
+[server.jury]
+address = "192.168.2.2:4000"
+client_limit = 5
+static = "./static/jury"
+
+[server.jury.endpoints]
+pod_data = "/podDataStructure"
+order_data = "/orderStructures"
+programable_boards = "/uploadableBoards"
+connections = "/backend"
 file_server = "/"
 
 [vehicle.network]
@@ -46,11 +70,11 @@ message_ids_table = "message_ids"
 [logger_handler]
 topics = { enable = "logger/enable" }
 base_path = "log"
-flush_interval="5s"
+flush_interval = "5s"
 
 [packet_logger]
 file_name = "packets"
-flush_interval="5s"
+flush_interval = "5s"
 
 [value_logger]
 folder_name = "values"
@@ -58,11 +82,11 @@ flush_interval = "5s"
 
 [order_logger]
 file_name = "orders"
-flush_interval="5s"
+flush_interval = "5s"
 
 [protection_logger]
 file_name = "protections"
-flush_interval="5s"
+flush_interval = "5s"
 
 [orders]
 send_topic = "order/send"
@@ -85,3 +109,8 @@ ack = { name = "tftp_ack" }
 [blcu.topics]
 upload = "blcu/upload"
 download = "blcu/download"
+
+[test]
+a = 10
+b = 20
+c = 30

--- a/src/config.toml
+++ b/src/config.toml
@@ -114,8 +114,3 @@ ack = { name = "tftp_ack" }
 [blcu.topics]
 upload = "blcu/upload"
 download = "blcu/download"
-
-[test]
-a = 10
-b = 20
-c = 30

--- a/src/go.mod
+++ b/src/go.mod
@@ -48,4 +48,4 @@ require (
 	golang.org/x/net v0.9.0 // indirect
 )
 
-replace github.com/HyperloopUPV-H8/ade-linter => ../../ade-linter
+replace github.com/HyperloopUPV-H8/ade-linter => ../../../utilities/lint/ade-linter

--- a/src/go.mod
+++ b/src/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/HyperloopUPV-H8/ade-linter v0.0.0-20230502150353-66a5396676ec
 	github.com/google/gopacket v1.1.19
-	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/pelletier/go-toml/v2 v2.0.7
@@ -21,6 +20,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.7.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect

--- a/src/main.go
+++ b/src/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"path"
@@ -51,7 +50,6 @@ func main() {
 	flag.Parse()
 
 	config := getConfig("./config.toml")
-	log.Println(config.Test)
 
 	excelAdapter := excel_adapter.New(config.Excel)
 	boards := excelAdapter.GetBoards()

--- a/src/server/config.go
+++ b/src/server/config.go
@@ -1,0 +1,24 @@
+package server
+
+type Config map[string]ServerConfig
+
+type ServerConfig struct {
+	Addr           string         `toml:"address" default:"localhost:4000"`
+	MaxConnections *int32         `toml:"client_limit,omitempty"`
+	Endpoints      EndpointConfig `toml:"endpoints"`
+	StaticPath     string         `toml:"static" default:"./static"`
+}
+
+type EndpointConfig struct {
+	PodData           string `toml:"pod_data" default:"/podDataStructure"`
+	OrderData         string `toml:"order_data" default:"/orderStructures"`
+	ProgramableBoards string `toml:"programable_boards" default:"/uploadableBoards"`
+	Connections       string `toml:"connections" default:"/backend"`
+	Files             string `toml:"files" default:"/"`
+}
+
+type EndpointData struct {
+	PodData           any
+	OrderData         any
+	ProgramableBoards any
+}

--- a/src/server/handler.go
+++ b/src/server/handler.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"fmt"
+	"sync"
+)
+
+type Handler struct {
+	config   Config
+	serverMx *sync.Mutex
+	servers  map[string]*WebServer
+}
+
+func New(connections ConnectionHandler, data EndpointData, config Config) (*Handler, error) {
+	handler := &Handler{
+		config:   config,
+		serverMx: &sync.Mutex{},
+		servers:  make(map[string]*WebServer, len(config)),
+	}
+
+	for name, serverConfig := range config {
+		connections.AddServer(name)
+		server, err := NewWebServer(name, connections, data, serverConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		handler.AddWebServer(name, server)
+	}
+
+	return handler, nil
+}
+
+func (handler *Handler) AddWebServer(name string, server *WebServer) error {
+	handler.serverMx.Lock()
+	defer handler.serverMx.Unlock()
+
+	if _, ok := handler.servers[name]; ok {
+		return fmt.Errorf("server %s already exists", name)
+	}
+
+	handler.servers[name] = server
+	return nil
+}
+
+func (handler *Handler) ListenAndServe() <-chan error {
+	errs := make(chan error, len(handler.servers))
+
+	for name := range handler.servers {
+		go handler.consumeErrors(name, handler.servers[name].ListenAndServe(), errs)
+	}
+
+	return errs
+}
+
+func (handler *Handler) consumeErrors(name string, serverErrs <-chan error, errs chan<- error) {
+	for err := range serverErrs {
+		errs <- err
+		handler.RemoveServer(name)
+	}
+}
+
+func (handler *Handler) RemoveServer(name string) {
+	handler.serverMx.Lock()
+	defer handler.serverMx.Unlock()
+
+	delete(handler.servers, name)
+}

--- a/src/server/websocket.go
+++ b/src/server/websocket.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/gorilla/websocket"
+	trace "github.com/rs/zerolog/log"
+)
+
+type ConnectionHandler interface {
+	AddServer(string)
+	Add(string, *websocket.Conn) error
+	Remove(string) <-chan struct{}
+}
+
+func (server *WebServer) serveWebsocket(path string, upgrader *websocket.Upgrader, headers map[string]string) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		trace.Info().Str("server", server.name).Msg("websocket connection")
+		for key, value := range headers {
+			w.Header().Set(key, value)
+		}
+
+		if server.config.MaxConnections != nil && server.connected.Load() >= *server.config.MaxConnections {
+			http.Error(w, "Max connections reached", http.StatusTooManyRequests)
+			return
+		}
+
+		conn, err := upgrader.Upgrade(w, r, w.Header())
+		if err != nil {
+			return
+		}
+
+		err = server.connections.Add(server.name, conn)
+		if err != nil {
+			return
+		}
+		server.connected.Add(1)
+
+	}
+
+	server.router.HandleFunc(path, handler)
+}
+
+func (server *WebServer) consumeRemoved() {
+	channel := server.connections.Remove(server.name)
+	for range channel {
+		server.connected.Add(-1)
+	}
+}


### PR DESCRIPTION
This PR adds the ability to add or remove http servers via `config.toml`. Each server has its own endpoints, static path and client limit (optional). To configure a server add a section to the `config.toml` like this:

```toml
[server.audience]
address = "172.16.0.2:4000"
client_limit = 2
static = "./static/audience"

[server.audience.endpoints]
pod_data = "/podDataStructure"
order_data = "/orderStructures"
programable_boards = "/uploadableBoards"
connections = "/backend"
file_server = "/"
```

In the example the new server will be called audience, it will be hosted on 172.16.0.2:4000 and will have a client limit of 2. If the client limit is omited, it has no limit to the number of clients that can connect.

`websocket_broker` has been changed to accommodate for the changes, it now notifies through a channel when a client has been disconnected so the number of connected clients can be tracked correctly.