### PR TITLE
[PR 1] DEV-176 Restructured excel_adapter

### DIFF
--- a/src/common/slice.go
+++ b/src/common/slice.go
@@ -17,3 +17,23 @@ func Filter[T any](items []T, predicate func(item T) bool) []T {
 
 	return newSlice
 }
+
+func Map[T any, U any](items []T, mapFn func(item T) U) []U {
+	result := make([]U, len(items))
+
+	for index, item := range items {
+		result[index] = mapFn(item)
+	}
+
+	return result
+}
+
+func Every[T any](slice []T, predicate func(T) bool) bool {
+	for _, item := range slice {
+		if !predicate(item) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/src/excel/ade/ade.go
+++ b/src/excel/ade/ade.go
@@ -1,0 +1,50 @@
+package ade
+
+import (
+	"errors"
+
+	doc "github.com/HyperloopUPV-H8/Backend-H8/excel/document"
+	"github.com/xuri/excelize/v2"
+)
+
+const (
+	InfoName = "GLOBAL INFO" //TODO: change to INFO
+)
+
+func CreateADE(file *excelize.File) (ADE, error) {
+	document := doc.CreateDocument(file)
+	infoSheet, ok := document.Sheets[InfoName]
+
+	if !ok {
+		return ADE{}, errors.New("info sheet not found")
+	}
+
+	info, err := getInfo(infoSheet)
+
+	if err != nil {
+		return ADE{}, err
+	}
+
+	boardSheets := FilterMap(document.Sheets, func(name string, _ doc.Sheet) bool {
+		return name != InfoName
+	})
+
+	boards := getBoards(boardSheets)
+
+	return ADE{
+		Info:   info,
+		Boards: boards,
+	}, nil
+}
+
+func FilterMap[K comparable, V any](myMap map[K]V, predicate func(key K, value V) bool) map[K]V {
+	filteredMap := make(map[K]V)
+
+	for key, value := range myMap {
+		if predicate(key, value) {
+			filteredMap[key] = value
+		}
+	}
+
+	return filteredMap
+}

--- a/src/excel/ade/ade_test.go
+++ b/src/excel/ade/ade_test.go
@@ -1,0 +1,24 @@
+package ade
+
+import (
+	"testing"
+
+	"github.com/xuri/excelize/v2"
+)
+
+func TestAde(t *testing.T) {
+	t.Run("correct ade is parsed without errors", func(t *testing.T) {
+		file, err := excelize.OpenFile("ade.xlsx")
+
+		if err != nil {
+			t.Fatalf("opening file: %e", err)
+		}
+
+		_, err = CreateADE(file)
+
+		if err != nil {
+			t.Fatalf("creating ade: %e", err)
+		}
+	})
+
+}

--- a/src/excel/ade/boards.go
+++ b/src/excel/ade/boards.go
@@ -1,0 +1,205 @@
+package ade
+
+import (
+	"fmt"
+	"strings"
+
+	doc "github.com/HyperloopUPV-H8/Backend-H8/excel/document"
+)
+
+const BoardPrefix = "BOARD "
+
+const (
+	PacketTable      = "Packets"
+	MeasurementTable = "Measurements"
+	Structures       = "Structures"
+)
+
+var (
+	PacketHeaders      = []string{"ID", "Name", "Type"}
+	MeasurementHeaders = []string{"ID", "Name", "Type", "PodUnits", "DisplayUnits", "SafeRange", "WarningRange"}
+)
+
+func getBoards(sheets map[string]doc.Sheet) map[string]Board {
+	boards := make(map[string]Board)
+
+	for name, sheet := range sheets {
+		name := strings.TrimPrefix(name, BoardPrefix)
+		board, err := getBoard(name, sheet)
+
+		if err != nil {
+			continue
+		}
+
+		boards[name] = board
+	}
+
+	return boards
+}
+
+func getBoard(name string, sheet doc.Sheet) (Board, error) {
+	packets := getPackets(sheet)
+	measurements := getMeasurements(sheet)
+	structures := getStructures(sheet)
+
+	return Board{
+		Name:         name,
+		Packets:      packets,
+		Measurements: measurements,
+		Structures:   structures,
+	}, nil
+}
+
+func getPackets(sheet doc.Sheet) []Packet {
+	packetTable, err := getTable(PacketTable, sheet, PacketHeaders)
+
+	if err != nil {
+		return make([]Packet, 0)
+	}
+
+	packets := make([]Packet, 0)
+
+	for _, row := range packetTable {
+		packets = append(packets, Packet{
+			Id:   row[0],
+			Name: row[1],
+			Type: row[2],
+		})
+	}
+
+	return packets
+}
+
+func getMeasurements(sheet doc.Sheet) []Measurement {
+	measurementTable, err := getTable(MeasurementTable, sheet, MeasurementHeaders)
+
+	if err != nil {
+		return make([]Measurement, 0)
+	}
+
+	measurements := make([]Measurement, 0)
+
+	for _, row := range measurementTable {
+		measurements = append(measurements, Measurement{
+			Id:           row[0],
+			Name:         row[1],
+			Type:         row[2],
+			PodUnits:     row[3],
+			DisplayUnits: row[4],
+			SafeRange:    row[5],
+			WarningRange: row[6],
+		})
+	}
+
+	return measurements
+}
+
+func getStructures(sheet doc.Sheet) []Structure {
+	structuresTable, err := findTableAutoSize(sheet, Structures)
+
+	if err != nil {
+		return make([]Structure, 0)
+	}
+
+	structuresTable = getStructureColumns(structuresTable)
+
+	structures := make([]Structure, 0)
+
+	for _, col := range structuresTable {
+		if len(col) == 1 {
+			structures = append(structures, Structure{
+				Packet:       col[0],
+				Measurements: make([]string, 0),
+			})
+		} else {
+			structures = append(structures, Structure{
+				Packet:       col[0],
+				Measurements: col[1:],
+			})
+		}
+	}
+
+	return structures
+}
+
+func getTable(name string, sheet doc.Sheet, headers []string) (Table, error) {
+	table, ok := findTable(sheet, name, len(headers))
+
+	if !ok {
+		return Table{}, fmt.Errorf("table %s not found", name)
+	}
+
+	if len(table) == 0 {
+		return Table{}, fmt.Errorf("table %s is empty (not even headers)", name)
+	}
+
+	if !areHeadersCorrect(table[0], headers) {
+		return Table{}, fmt.Errorf("incorrect headers: %v", table[0])
+	}
+
+	if len(table) == 1 {
+		return Table{}, fmt.Errorf("table %s has no fields", name)
+	}
+
+	return table[1:], nil
+}
+
+func areHeadersCorrect(headerRow []string, headers []string) bool {
+	if len(headerRow) != len(headers) {
+		return false
+	}
+
+	for index, header := range headers {
+		if !(header == headerRow[index]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func getStructureColumns(rows [][]string) [][]string {
+	structures := rows[1:]
+	structures = toColumns(structures)
+
+	croppedStructures := make([][]string, 0)
+outer:
+	for _, column := range structures {
+		for j, cell := range column {
+			if cell == "" {
+				croppedStructures = append(croppedStructures, column[:j])
+				continue outer
+			}
+		}
+		croppedStructures = append(croppedStructures, column)
+	}
+
+	return croppedStructures
+}
+
+func toColumns(rows [][]string) [][]string {
+	if len(rows) == 0 {
+		return rows
+	}
+
+	columns := make([][]string, 0)
+	for i := 0; i < len(rows[0]); i++ {
+		columns = append(columns, toColumn(rows, i))
+	}
+
+	return columns
+}
+
+func toColumn(rows [][]string, col int) []string {
+	if len(rows) == 0 {
+		return make([]string, 0)
+	}
+
+	column := make([]string, 0)
+
+	for i := 0; i < len(rows); i++ {
+		column = append(column, rows[i][col])
+	}
+
+	return column
+}

--- a/src/excel/ade/boards.go
+++ b/src/excel/ade/boards.go
@@ -133,29 +133,12 @@ func getTable(name string, sheet doc.Sheet, headers []string) (Table, error) {
 		return Table{}, fmt.Errorf("table %s is empty (not even headers)", name)
 	}
 
-	if !areHeadersCorrect(table[0], headers) {
-		return Table{}, fmt.Errorf("incorrect headers: %v", table[0])
-	}
-
 	if len(table) == 1 {
-		return Table{}, fmt.Errorf("table %s has no fields", name)
+		return table, nil
+	} else {
+		return table[1:], nil
 	}
 
-	return table[1:], nil
-}
-
-func areHeadersCorrect(headerRow []string, headers []string) bool {
-	if len(headerRow) != len(headers) {
-		return false
-	}
-
-	for index, header := range headers {
-		if !(header == headerRow[index]) {
-			return false
-		}
-	}
-
-	return true
 }
 
 func getStructureColumns(rows [][]string) [][]string {

--- a/src/excel/ade/info.go
+++ b/src/excel/ade/info.go
@@ -1,0 +1,90 @@
+package ade
+
+import (
+	"errors"
+
+	doc "github.com/HyperloopUPV-H8/Backend-H8/excel/document"
+)
+
+const (
+	Addresses  = "addresses"
+	Units      = "units"
+	Ports      = "ports"
+	BoardIds   = "board_ids"
+	MessageIds = "message_ids"
+	BackendKey = "Backend"
+)
+
+func getInfo(sheet doc.Sheet) (Info, error) {
+	tables, err := getTables(sheet)
+
+	if err != nil {
+		return Info{}, err
+	}
+
+	addresses, ok := tables[Addresses]
+
+	if !ok {
+		return Info{}, errors.New("addresses table not found")
+	}
+
+	addresses = removeHeaders(addresses)
+
+	units, ok := tables[Units]
+
+	if !ok {
+		return Info{}, errors.New("units table not found")
+	}
+
+	units = removeHeaders(units)
+
+	ports, ok := tables[Ports]
+
+	if !ok {
+		return Info{}, errors.New("ports table not found")
+	}
+
+	ports = removeHeaders(ports)
+
+	boardIds, ok := tables[BoardIds]
+
+	if !ok {
+		return Info{}, errors.New("boardIds table not found")
+	}
+
+	boardIds = removeHeaders(boardIds)
+
+	messageIds, ok := tables[MessageIds]
+
+	if !ok {
+		return Info{}, errors.New("messageIds table not found")
+	}
+
+	messageIds = removeHeaders(messageIds)
+
+	return Info{
+		Addresses:  tableToMap(addresses),
+		Units:      tableToMap(units),
+		Ports:      tableToMap(ports),
+		BoardIds:   tableToMap(boardIds),
+		MessageIds: tableToMap(messageIds),
+	}, nil
+}
+
+func removeHeaders(table Table) Table {
+	if len(table) == 0 {
+		return table
+	}
+
+	return table[1:]
+}
+
+func tableToMap(table [][]string) map[string]string {
+	m := make(map[string]string, len(table))
+
+	for _, row := range table {
+		m[row[0]] = row[1]
+	}
+
+	return m
+}

--- a/src/excel/ade/models.go
+++ b/src/excel/ade/models.go
@@ -1,0 +1,42 @@
+package ade
+
+type ADE struct {
+	Info   Info
+	Boards map[string]Board
+}
+
+type Info struct {
+	Addresses  map[string]string
+	Units      map[string]string
+	Ports      map[string]string
+	BoardIds   map[string]string
+	MessageIds map[string]string
+}
+
+type Board struct {
+	Name         string
+	Packets      []Packet
+	Measurements []Measurement
+	Structures   []Structure
+}
+
+type Packet struct {
+	Id   string
+	Name string
+	Type string
+}
+
+type Measurement struct {
+	Id           string
+	Name         string
+	Type         string
+	PodUnits     string
+	DisplayUnits string
+	SafeRange    string
+	WarningRange string
+}
+
+type Structure struct {
+	Packet       string
+	Measurements []string
+}

--- a/src/excel/ade/table.go
+++ b/src/excel/ade/table.go
@@ -1,0 +1,134 @@
+package ade
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/HyperloopUPV-H8/Backend-H8/common"
+	doc "github.com/HyperloopUPV-H8/Backend-H8/excel/document"
+)
+
+type Table = [][]string
+
+const TablePrefix = "[TABLE]"
+
+func getTables(sheet [][]string) (map[string]Table, error) {
+	tables := make(map[string]Table)
+
+	for i, row := range sheet {
+		for j, cell := range row {
+			if strings.HasPrefix(cell, TablePrefix) {
+				name := strings.TrimPrefix(cell, fmt.Sprintf("%s ", TablePrefix))
+				table, err := getTableAutoSize(sheet, i, j)
+
+				if err != nil {
+					return nil, nil
+				}
+
+				tables[name] = table
+			}
+		}
+	}
+
+	return tables, nil
+}
+
+func findTable(sheet [][]string, name string, width int) (Table, bool) {
+	row, col := findTableHeader(sheet, name)
+
+	if row == -1 || col == -1 {
+		return [][]string{}, false
+	}
+
+	if row == len(sheet)-1 {
+		return make([][]string, 0), true
+	}
+
+	return getTableWithWidth(sheet, row+1, col, width), true
+}
+
+func findTableAutoSize(sheet doc.Sheet, name string) (Table, error) {
+	row, col := findTableHeader(sheet, name)
+
+	if row == -1 || col == -1 {
+		return [][]string{}, fmt.Errorf("table %s not found", name)
+	}
+
+	table, err := getTableAutoSize(sheet, row, col)
+
+	if err != nil {
+		return [][]string{}, err
+	}
+
+	return table, nil
+}
+
+func findTableHeader(sheet doc.Sheet, name string) (int, int) { // returns row, col
+	for i, row := range sheet {
+		for k, cell := range row {
+			if cell == fmt.Sprint(TablePrefix, " ", name) {
+				return i, k
+			}
+		}
+	}
+
+	return -1, -1
+}
+
+func getTableWithWidth(sheet doc.Sheet, row int, col int, width int) Table {
+	colLength := getLongestColumn(sheet, row, col, width)
+	return getSubmatrix(sheet, row, width, col, colLength)
+}
+
+func getTableAutoSize(sheet doc.Sheet, row int, column int) ([][]string, error) {
+	if row == len(sheet)-1 {
+		return [][]string{}, fmt.Errorf("table header is in the last row")
+	}
+
+	rowLength := getRowLength(sheet[row+1][column:])
+	columnLength := getLongestColumn(sheet, row+1, column, rowLength)
+
+	return getSubmatrix(sheet, row+1, rowLength, column, columnLength), nil
+}
+
+func getRowLength(row []string) int {
+	if len(row) == 0 {
+		return 0
+	}
+
+	for i, cell := range row {
+		if cell == "" {
+			return i
+		}
+	}
+
+	return len(row)
+}
+
+func getLongestColumn(sheet doc.Sheet, row int, col int, nCols int) int {
+	for i := row; i < len(sheet); i++ {
+		if isRowEmpty(sheet[i][col : col+nCols]) {
+			return i - row
+		}
+	}
+
+	return len(sheet) - row
+}
+
+func isRowEmpty(row []string) bool {
+	return common.Every(row, func(item string) bool {
+		return item == ""
+	})
+}
+
+func getSubmatrix[T any](matrix [][]T, startRow int, rowLength int, startCol int, colLength int) [][]T {
+	rows := matrix[startRow : startRow+colLength]
+
+	submatrix := make([][]T, len(rows))
+
+	for index, row := range rows {
+		submatrix[index] = row[startCol : startCol+rowLength]
+	}
+
+	return submatrix
+}

--- a/src/excel/document/document.go
+++ b/src/excel/document/document.go
@@ -1,0 +1,58 @@
+package document
+
+import (
+	"github.com/xuri/excelize/v2"
+)
+
+func CreateDocument(file *excelize.File) Document {
+	fileSheets := getFileSheets(file)
+
+	return Document{
+		Sheets: getRectSheets(fileSheets),
+	}
+}
+
+func getFileSheets(file *excelize.File) map[string][][]string {
+	fileSheets := make(map[string][][]string)
+	sheetMap := file.GetSheetMap()
+	for _, name := range sheetMap {
+		sheet, err := file.GetRows(name)
+
+		if err != nil {
+			continue
+		}
+
+		fileSheets[name] = sheet
+	}
+
+	return fileSheets
+}
+
+func getRectSheets(sheets map[string][][]string) map[string][][]string {
+	rectSheets := make(map[string][][]string)
+
+	for name, sheet := range sheets {
+		rectSheets[name] = makeSheetRect(sheet)
+	}
+
+	return rectSheets
+}
+
+func makeSheetRect(sheet [][]string) [][]string {
+	maxLength := 0
+
+	for _, row := range sheet {
+		if len(row) > maxLength {
+			maxLength = len(row)
+		}
+	}
+
+	fullRows := make([][]string, 0)
+	for _, row := range sheet {
+		fullRow := make([]string, maxLength)
+		copy(fullRow, row)
+		fullRows = append(fullRows, fullRow)
+	}
+
+	return fullRows
+}

--- a/src/excel/document/models.go
+++ b/src/excel/document/models.go
@@ -1,0 +1,7 @@
+package document
+
+type Document struct {
+	Sheets map[string]Sheet
+}
+
+type Sheet = [][]string

--- a/src/excel/download.go
+++ b/src/excel/download.go
@@ -1,0 +1,110 @@
+package excel
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/pkg/errors"
+	trace "github.com/rs/zerolog/log"
+	"github.com/xuri/excelize/v2"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+
+	_ "embed"
+)
+
+const SHEETS_MIME_TYPE = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
+var (
+	ErrClient   = "getting client"
+	ErrDownload = "getting file"
+	ErrSaving   = "saving file"
+	ErrOpening  = "opening file"
+)
+
+type DownloadConfig struct {
+	Id   string
+	Path string
+	Name string
+}
+
+//go:embed secret.json
+var apiKey []byte
+
+func Download(config DownloadConfig) (*excelize.File, error) {
+	trace.Trace().Str("id", config.Id).Str("path", config.Path).Str("name", config.Name).Msg("download file")
+	client, errClient := getClient(apiKey)
+	if errClient != nil {
+		trace.Error().Str("id", config.Id).Str("path", config.Path).Str("name", config.Name).Stack().Err(errClient).Msg("")
+		return nil, errors.Wrap(errClient, ErrClient)
+	}
+
+	fileBuf, errFile := getFile(client, config.Id, SHEETS_MIME_TYPE)
+	if errFile != nil {
+		trace.Error().Str("id", config.Id).Str("path", config.Path).Str("name", config.Name).Stack().Err(errFile).Msg("")
+		return nil, errors.Wrap(errFile, ErrDownload)
+	}
+
+	errSaving := saveFile(fileBuf, config.Path, config.Name)
+	if errSaving != nil {
+		trace.Error().Str("id", config.Id).Str("path", config.Path).Str("name", config.Name).Stack().Err(errSaving).Msg("")
+	}
+
+	if errSaving != nil {
+		return nil, errors.Wrap(errSaving, ErrSaving)
+	}
+
+	file, errOpening := excelize.OpenFile(filepath.Join(config.Path, config.Name))
+	if errOpening != nil {
+		return nil, errors.Wrap(errOpening, ErrOpening)
+	}
+
+	return file, nil
+}
+
+func getClient(apiKey []byte) (*drive.Service, error) {
+	trace.Trace().Msg("get client")
+	ctx := context.Background()
+
+	client, err := drive.NewService(ctx, option.WithCredentialsJSON(apiKey))
+
+	if err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
+func getFile(client *drive.Service, id string, mimeType string) ([]byte, error) {
+	trace.Trace().Str("id", id).Msg("get file")
+	resp, err := client.Files.Export(id, mimeType).Download()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func saveFile(content []byte, path string, name string) error {
+	trace.Trace().Str("path", path).Str("name", name).Msg("save file")
+
+	err := os.Mkdir(path, 0777)
+
+	if !os.IsExist(err) {
+		return err
+	}
+
+	err = os.WriteFile(filepath.Join(path, name), content, 0644) // rw-r--r--
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/excel_adapter/models/from_document.go
+++ b/src/excel_adapter/models/from_document.go
@@ -1,6 +1,0 @@
-package models
-
-type FromDocument interface {
-	AddGlobal(GlobalInfo)
-	AddPacket(boardName string, packet Packet)
-}

--- a/src/go.mod
+++ b/src/go.mod
@@ -46,5 +46,3 @@ require (
 	github.com/fatih/color v1.15.0
 	golang.org/x/net v0.9.0 // indirect
 )
-
-replace github.com/HyperloopUPV-H8/ade-linter => ../../../utilities/lint/ade-linter

--- a/src/go.sum
+++ b/src/go.sum
@@ -6,6 +6,8 @@ cloud.google.com/go/compute/metadata v0.2.1 h1:efOwf5ymceDhK6PKMnnrTHP4pppY5L22m
 cloud.google.com/go/compute/metadata v0.2.1/go.mod h1:jgHgmJd2RKBGzXqF5LR2EZMGxBkeanZ9wwa75XHJgOM=
 cloud.google.com/go/longrunning v0.1.1 h1:y50CXG4j0+qvEukslYFBCrzaXX0qpFbBzc3PchSu/LE=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/HyperloopUPV-H8/ade-linter v0.0.0-20230502150353-66a5396676ec h1:N0yFF+effK8K/vPBYHirq6fVc0qpXDMz8sojcRtq1os=
+github.com/HyperloopUPV-H8/ade-linter v0.0.0-20230502150353-66a5396676ec/go.mod h1:y2zH0pjAkyEirrmjDq/O3lg03whnTSk5KPtQwJLr0Q4=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
This is a rewrite of the excel adapter module. To do so I've included code from both the excel adapter and the ade linter (not validation, just some functions related to getting the tables from the sheet).

The excel goes through the following stages:
- First, it's downloaded and opened as a `*excelize.File` variable.
- Then, it's transformed to a `Document` variable, which just serves the purpose of simpliying the excelize.File variable and making the sheets square. It's an adapter.
- Finally, it's transformed into `ADE`. Everything is still a string, but is structured in the tables present in ADE. The sheets are also separated into Info and Boards in this step.

```mermaid
flowchart LR
*excelize.File --> Document --> ADE
```

My recommendation is you review this code by only searching for blatant mistakes, as pretty much everything was copied over from already accepted code.