### PR TITLE
[PR 1] DEV-186 ignore ID 0

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -242,7 +242,7 @@ func acceptInput(limit int) (int, error) {
 		}
 
 		if dev < 0 || dev >= limit {
-			red.Println("invalid device selected\n")
+			red.Println("invalid device selected")
 			continue
 		} else {
 			return dev, nil

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -48,6 +48,10 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmitte
 		payloadCopy := make([]byte, len(packet.Payload))
 		copy(payloadCopy, packet.Payload)
 
+		if packet.Metadata.ID == 0 {
+			continue
+		}
+
 		//TODO: add order decoding
 		switch id := packet.Metadata.ID; {
 		case vehicle.dataIds.Has(id):


### PR DESCRIPTION
FW uses ID 0 as an indicator to enter fault asap. It would cause the backend to print error messages all the time and we should not expect to handle it.

This just skips the loop iteration.