### PR TITLE
[PR 1] DEV-187 Select boards to connect to from config

### DIFF
--- a/src/config.toml
+++ b/src/config.toml
@@ -10,6 +10,9 @@ programable_boards = "/uploadableBoards"
 connections = "/backend"
 file_server = "/"
 
+[vehicle]
+boards = ["LCU_MASTER"]
+
 [vehicle.network]
 tcp_client_tag = "TCP_CLIENT"
 tcp_server_tag = "TCP_SERVER"

--- a/src/pipe/constructor.go
+++ b/src/pipe/constructor.go
@@ -10,10 +10,22 @@ import (
 	trace "github.com/rs/zerolog/log"
 )
 
-func CreatePipes(global excel_models.GlobalInfo, dataChan chan<- packet.Packet, onConnectionChange func(string, bool), config Config, trace zerolog.Logger) map[string]*Pipe {
+func contains(boards []string, board string) bool {
+	for _, b := range boards {
+		if b == board {
+			return true
+		}
+	}
+	return false
+}
+
+func CreatePipes(global excel_models.GlobalInfo, boards []string, dataChan chan<- packet.Packet, onConnectionChange func(string, bool), config Config, trace zerolog.Logger) map[string]*Pipe {
 	laddr := common.AddrWithPort(global.BackendIP, global.ProtocolToPort[config.TcpClientTag])
 	pipes := make(map[string]*Pipe)
 	for board, ip := range global.BoardToIP {
+		if boards != nil && !contains(boards, board) {
+			continue
+		}
 		raddr := common.AddrWithPort(ip, global.ProtocolToPort[config.TcpServerTag])
 		pipe, err := newPipe(laddr, raddr, config.Mtu, dataChan, getOnConnectionChange(board, onConnectionChange))
 		if err != nil {

--- a/src/vehicle/config.go
+++ b/src/vehicle/config.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Config struct {
+	Boards       []string             `toml:"boards,omitempty"`
 	Network      NetworkConfig        `toml:"network"`
 	PacketParser packet_parser.Config `toml:"packet_parser"`
 	Messages     MessageConfig        `toml:"messages"`

--- a/src/vehicle/constructor.go
+++ b/src/vehicle/constructor.go
@@ -65,7 +65,7 @@ func New(args VehicleConstructorArgs) Vehicle {
 		displayConverter: unit_converter.NewUnitConverter("display", args.Boards, args.GlobalInfo.UnitToOperations),
 
 		sniffer: sniffer.CreateSniffer(args.GlobalInfo, snifferConfig, vehicleTrace),
-		pipes:   pipe.CreatePipes(args.GlobalInfo, dataChan, args.OnConnectionChange, pipesConfig, vehicleTrace),
+		pipes:   pipe.CreatePipes(args.GlobalInfo, args.Config.Boards, dataChan, args.OnConnectionChange, pipesConfig, vehicleTrace),
 
 		dataIds:       getBoardIdsFromType(args.Boards, "data", vehicleTrace),
 		orderIds:      getBoardIdsFromType(args.Boards, "order", vehicleTrace),


### PR DESCRIPTION
This adds a new field to the vehicle configuration: `boards` which allows the user to select to what boards should the backend connect. The field can be either present or not in the config.

When present it is a list of strings, where the strings should be the name of the board (as is in the ADE) that the backend should attempt to connect.

If not present in the config toml, the backend will attempt to connect to all boards