### PR TITLE
[PR 1] DEV-189 add release github action

### DIFF
--- a/.github/workflows/pre-release.yaml
+++ b/.github/workflows/pre-release.yaml
@@ -1,0 +1,38 @@
+name: Create Release
+
+on:
+  push:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build-binary:
+    name: "Release app"
+    runs-on: alpine-latest
+
+    steps:
+      - name: "Download dependencies"
+        run: |
+          apk add --no-cache libpcap-dev musl-dev gcc
+
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Build for linux"
+        run: |
+          CGO_ENABLED=1 GOARCH=amd64 GOOS=linux go build -ldflags '-linkmode external -extldflags "-static"' -o backend-linux
+
+    #   - name: "Build for windows"
+    #     run: |
+    #       CGO_ENABLED=1 GOOS=windows go build -ldflags '-linkmode external -extldflags "-static"' -o backend-windows.exe
+
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          files: |
+            backend-linux
+            # backend-windows.exe
+
+      

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,37 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-binary:
+    name: "Release app"
+    runs-on: alpine-latest
+
+    steps:
+      - name: "Download dependencies"
+        run: |
+          apk add --no-cache libpcap-dev musl-dev gcc
+
+      - name: "Checkout"
+        uses: actions/checkout@v2
+
+      - name: "Build for linux"
+        run: |
+          CGO_ENABLED=1 GOARCH=amd64 GOOS=linux go build -ldflags '-linkmode external -extldflags "-static"' -o backend-linux
+
+    #   - name: "Build for windows"
+    #     run: |
+    #       CGO_ENABLED=1 GOOS=windows go build -ldflags '-linkmode external -extldflags "-static"' -o backend-windows.exe
+
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: false
+          files: |
+            backend-linux
+            # backend-windows.exe
+
+      


### PR DESCRIPTION
This adds a workflow to create a pre releas each time a change is pushed to develop or main, and create a full release when we push a change with a version tag such as `v1.0.0`.

Currently it only builds binaries for linux.