### PR TITLE
[PR 1] DEV-190 no cache

### DIFF
--- a/src/server/websocket.go
+++ b/src/server/websocket.go
@@ -12,7 +12,7 @@ type ConnectionHandler interface {
 }
 
 func (server *WebServer) serveWebsocket(path string, upgrader *websocket.Upgrader, headers map[string]string) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		trace.Info().Str("server", server.name).Msg("websocket connection")
 		for key, value := range headers {
 			w.Header().Set(key, value)
@@ -39,7 +39,7 @@ func (server *WebServer) serveWebsocket(path string, upgrader *websocket.Upgrade
 		}
 		server.connected.Add(1)
 
-	}
+	})
 
-	server.router.HandleFunc(path, handler)
+	server.router.Handle(path, NoCacheMiddleware(handler))
 }


### PR DESCRIPTION
This PR adds the `Cache-Control` and `Pragma` headers set to `no-cache` for every request made to the backend in order to prevent the browser from caching an old frontend version