### PR TITLE
[PR 1] DEV-193 add Keepalive interval and Write timeout configuration

### DIFF
--- a/examples/config.toml
+++ b/examples/config.toml
@@ -17,10 +17,10 @@ boards = ["VCU"]
 tcp_client_tag = "TCP_CLIENT"
 tcp_server_tag = "TCP_SERVER"
 udp_tag = "UDP"
-# sniffer = { mtu = 1500, interface = "lo" }
 mtu = 1500
 interface = "lo"
-# blcu_ack_id = "blcu_ack"
+keepalive = "1s"
+timeout = "1s"
 
 [vehicle.messages]
 info_id_key = "info"
@@ -33,7 +33,6 @@ remove_state_orders_id_key = "remove_state_orders"
 
 [excel.download]
 id = "1BEwASubu0el9oQA6PSwVKaNU-Q6gbJ40JR6kgqguKYE"
-# id = "1l3YbwL2fPzehZc1kO0KySp84IzepfwzqT7XUWVQjk3Q"
 name = "ade.xlsx"
 path = "."
 

--- a/src/config.toml
+++ b/src/config.toml
@@ -21,6 +21,8 @@ udp_tag = "UDP"
 mtu = 1500
 interface = "lo"
 # blcu_ack_id = "blcu_ack"
+keepalive = "1s"
+timeout = "1s"
 
 [vehicle.messages]
 info_id_key = "info"

--- a/src/pipe/pipe.go
+++ b/src/pipe/pipe.go
@@ -162,5 +162,5 @@ func (pipe *Pipe) SendFault(from string, payload []byte) {
 		return
 	}
 
-	pipe.Write(append([]byte{0x01, 0x00}, payload...))
+	pipe.Write(append([]byte{0x02, 0x00}, payload...))
 }

--- a/src/pipe/pipe.go
+++ b/src/pipe/pipe.go
@@ -162,5 +162,5 @@ func (pipe *Pipe) SendFault(from string, payload []byte) {
 		return
 	}
 
-	pipe.Write(append([]byte{0x02, 0x00}, payload...))
+	pipe.Write(append([]byte{0x01, 0x00}, payload...))
 }

--- a/src/pipe/pipe.go
+++ b/src/pipe/pipe.go
@@ -156,11 +156,3 @@ func (pipe *Pipe) Laddr() string {
 func (pipe *Pipe) Raddr() string {
 	return pipe.raddr.String()
 }
-
-func (pipe *Pipe) SendFault(from string, payload []byte) {
-	if from == pipe.raddr.String() {
-		return
-	}
-
-	pipe.Write(append([]byte{0x01, 0x00}, payload...))
-}

--- a/src/pipe/pipe.go
+++ b/src/pipe/pipe.go
@@ -156,3 +156,11 @@ func (pipe *Pipe) Laddr() string {
 func (pipe *Pipe) Raddr() string {
 	return pipe.raddr.String()
 }
+
+func (pipe *Pipe) SendFault(from string, payload []byte) {
+	if from == pipe.raddr.String() {
+		return
+	}
+
+	pipe.Write(append([]byte{0x01, 0x00}, payload...))
+}

--- a/src/vehicle/config.go
+++ b/src/vehicle/config.go
@@ -1,7 +1,10 @@
 package vehicle
 
 import (
+	"time"
+
 	"github.com/HyperloopUPV-H8/Backend-H8/vehicle/packet_parser"
+	"github.com/rs/zerolog/log"
 )
 
 type Config struct {
@@ -12,11 +15,35 @@ type Config struct {
 }
 
 type NetworkConfig struct {
-	TcpClientTag string `toml:"tcp_client_tag"`
-	TcpServerTag string `toml:"tcp_server_tag"`
-	UdpTag       string `toml:"udp_tag"`
-	Mtu          uint   `toml:"mtu"`
-	Interface    string `toml:"interface"`
+	TcpClientTag      string  `toml:"tcp_client_tag"`
+	TcpServerTag      string  `toml:"tcp_server_tag"`
+	UdpTag            string  `toml:"udp_tag"`
+	Mtu               uint    `toml:"mtu"`
+	Interface         string  `toml:"interface"`
+	KeepaliveInterval *string `toml:"keepalive,omitempty"`
+	WriteTimeout      *string `toml:"timeout,omitempty"`
+}
+
+func (networkConfig NetworkConfig) GetKeepaliveInterval() *time.Duration {
+	if networkConfig.KeepaliveInterval == nil {
+		return nil
+	}
+	interval, err := time.ParseDuration(*networkConfig.KeepaliveInterval)
+	if err != nil {
+		log.Fatal().Stack().Err(err).Str("interval", *networkConfig.KeepaliveInterval).Msg("error parsing keepalive interval")
+	}
+	return &interval
+}
+
+func (networkConfig NetworkConfig) GetWriteTimeout() *time.Duration {
+	if networkConfig.WriteTimeout == nil {
+		return nil
+	}
+	timeout, err := time.ParseDuration(*networkConfig.WriteTimeout)
+	if err != nil {
+		log.Fatal().Stack().Err(err).Str("timeout", *networkConfig.WriteTimeout).Msg("error parsing write timeout")
+	}
+	return &timeout
 }
 
 type MessageConfig struct {

--- a/src/vehicle/constructor.go
+++ b/src/vehicle/constructor.go
@@ -67,7 +67,7 @@ func New(args VehicleConstructorArgs) Vehicle {
 		displayConverter: unit_converter.NewUnitConverter("display", args.Boards, args.GlobalInfo.UnitToOperations),
 
 		sniffer: sniffer.CreateSniffer(args.GlobalInfo, snifferConfig, vehicleTrace),
-		pipes:   pipe.CreatePipes(args.GlobalInfo, args.Config.Boards, dataChan, args.OnConnectionChange, pipesConfig, pipeReaders, vehicleTrace),
+		pipes:   pipe.CreatePipes(args.GlobalInfo, args.Config.Network.GetKeepaliveInterval(), args.Config.Network.GetWriteTimeout(), args.Config.Boards, dataChan, args.OnConnectionChange, pipesConfig, pipeReaders, vehicleTrace),
 
 		dataIds:             getBoardIdsFromType(args.Boards, "data", vehicleTrace),
 		orderIds:            getBoardIdsFromType(args.Boards, "order", vehicleTrace),

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -43,6 +43,12 @@ type Vehicle struct {
 	trace zerolog.Logger
 }
 
+func (vehicle *Vehicle) propagateFault(source string, payload []byte) {
+	for _, pipe := range vehicle.pipes {
+		pipe.SendFault(source, payload)
+	}
+}
+
 func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmittedOrderChan chan<- models.PacketUpdate, messageChan chan<- any, blcuAckChan chan<- struct{}, stateOrdersChan chan<- message_parser.StateOrdersAdapter) {
 	vehicle.trace.Debug().Msg("vehicle listening")
 	for packet := range vehicle.dataChan {
@@ -51,6 +57,10 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmitte
 
 		if packet.Metadata.ID == 0 {
 			continue
+		}
+
+		if packet.Metadata.ID == 1 {
+			vehicle.propagateFault(packet.Metadata.From, packet.Payload)
 		}
 
 		//TODO: add order decoding

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -59,7 +59,7 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmitte
 			continue
 		}
 
-		if packet.Metadata.ID == 1 {
+		if packet.Metadata.ID == 2 {
 			vehicle.propagateFault(packet.Metadata.From, packet.Payload)
 		}
 

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -59,7 +59,7 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmitte
 			continue
 		}
 
-		if packet.Metadata.ID == 2 {
+		if packet.Metadata.ID == 1 {
 			vehicle.propagateFault(packet.Metadata.From, packet.Payload)
 		}
 

--- a/src/vehicle/vehicle.go
+++ b/src/vehicle/vehicle.go
@@ -43,12 +43,6 @@ type Vehicle struct {
 	trace zerolog.Logger
 }
 
-func (vehicle *Vehicle) propagateFault(source string, payload []byte) {
-	for _, pipe := range vehicle.pipes {
-		pipe.SendFault(source, payload)
-	}
-}
-
 func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmittedOrderChan chan<- models.PacketUpdate, messageChan chan<- any, blcuAckChan chan<- struct{}, stateOrdersChan chan<- message_parser.StateOrdersAdapter) {
 	vehicle.trace.Debug().Msg("vehicle listening")
 	for packet := range vehicle.dataChan {
@@ -57,10 +51,6 @@ func (vehicle *Vehicle) Listen(updateChan chan<- models.PacketUpdate, transmitte
 
 		if packet.Metadata.ID == 0 {
 			continue
-		}
-
-		if packet.Metadata.ID == 1 {
-			vehicle.propagateFault(packet.Metadata.From, packet.Payload)
 		}
 
 		//TODO: add order decoding


### PR DESCRIPTION
Add two new fields in the config.toml that allows to change the keepalive interval and write timeout of the pipes.

This also fixes a bug where the backend could only connect to one board. The problem was we were using the same local address for all the connecections, and whilst the raddrs were different (meaning different sockets), the OS uses the local port to notify the application. When acting as the client we were trying to create multiple connections with the same port, which caused all except one connection to actually connect, and the rest were throwing a silent error. The fix is to increase the port by one on each pipe.