### PR TITLE
[PR 1] DEV-198 fix protection pipe reader

### DIFF
--- a/src/vehicle/constructor.go
+++ b/src/vehicle/constructor.go
@@ -59,7 +59,7 @@ func New(args VehicleConstructorArgs) Vehicle {
 		displayConverter: unit_converter.NewUnitConverter("display", args.Boards, args.Info.Units),
 
 		sniffer: sniffer.CreateSniffer(args.Info, snifferConfig, vehicleTrace),
-		pipes:   pipe.CreatePipes(args.Info, args.Config.Network.GetKeepaliveInterval(), args.Config.Network.GetWriteTimeout(), args.Config.Boards, dataChan, args.OnConnectionChange, pipesConfig, pipeReaders, vehicleTrace),
+		pipes:   pipe.CreatePipes(args.Info, args.Config.Network.GetKeepaliveInterval(), args.Config.Network.GetWriteTimeout(), args.Config.Boards, dataChan, args.OnConnectionChange, pipesConfig, newPipeReaders(args.Info.MessageIds), vehicleTrace),
 
 		dataIds:             getBoardIdsFromType(args.Boards, "data", vehicleTrace),
 		orderIds:            getBoardIdsFromType(args.Boards, "order", vehicleTrace),


### PR DESCRIPTION
This PR fixes the pipe reader for protections to properly read the messages.

The protection messages carry a len field between the protection id and the json payload, which is an uint16. From this uint16 we get the length of the message and read that amount.

It also fixes a potential bug where the blcu ack was being parsed with a delimiter parser, which could cause problems because the message is just the id.

Finally I added a constructor to avoid hardcoded IDs, instead they are fetched from the same args passed to the vehicle constructor